### PR TITLE
Fixes Native Memory Leaks

### DIFF
--- a/benchmarks/tools/Build/nuget-local.targets
+++ b/benchmarks/tools/Build/nuget-local.targets
@@ -3,6 +3,7 @@
 
 	<Target Name="ClearPackageCache" BeforeTargets="Build" Condition="'$(CI)' == 'false'">
 		<Exec Command="rmdir /s /q %UserProfile%\.nuget\packages\FileOnQ.Imaging.Heif\0.0.0-local.1" />
+		<Exec Command="del FileOnQ.Imaging.Heif.0.0.0-local.1.*" WorkingDirectory="$(ProjectDir)../../" />
 	</Target>
 
 	<Target Name="CreatePackage" AfterTargets="ClearPackageCache" Condition="'$(CI)' == 'false'">

--- a/samples/ConsoleApp/ConsoleApp.Shared/Build/nuget-local.targets
+++ b/samples/ConsoleApp/ConsoleApp.Shared/Build/nuget-local.targets
@@ -3,6 +3,7 @@
 
 	<Target Name="ClearPackageCache" BeforeTargets="Build" Condition="'$(CI)' == 'false'">
 		<Exec Command="rmdir /s /q %UserProfile%\.nuget\packages\FileOnQ.Imaging.Heif\0.0.0-local.1" />
+		<Exec Command="del FileOnQ.Imaging.Heif.0.0.0-local.1.*" WorkingDirectory="$(ProjectDir)../../../" />
 	</Target>
 
 	<Target Name="CreatePackage" AfterTargets="ClearPackageCache" Condition="'$(CI)' == 'false'">

--- a/src/FileOnQ.Imaging.Heif/Image.cs
+++ b/src/FileOnQ.Imaging.Heif/Image.cs
@@ -41,6 +41,7 @@ namespace FileOnQ.Imaging.Heif
 				LibEncoder.GetChroma(encoder, hasAlpha, bitDepth),
 				decodingOptions);
 
+
 			if (decodeError.Code != LibHeif.ErrorCode.Ok)
 				throw new HeifException(decodeError);
 
@@ -88,6 +89,11 @@ namespace FileOnQ.Imaging.Heif
 					if ((IntPtr)buffer != IntPtr.Zero)
 					{
 						LibEncoder.Free((IntPtr)buffer);
+					}
+
+					if ((IntPtr)outputImage != IntPtr.Zero)
+					{
+						LibHeif.ReleaseImage(outputImage);
 					}
 				}
 			}

--- a/src/FileOnQ.Imaging.Heif/LibHeif/LibHeif.cs
+++ b/src/FileOnQ.Imaging.Heif/LibHeif/LibHeif.cs
@@ -181,5 +181,20 @@ namespace FileOnQ.Imaging.Heif
 					throw new NotSupportedException($"Current platform ({RuntimeInformation.ProcessArchitecture}) is not supported");
 			}
 		}
+
+		internal static void ReleaseImage(Image* image)
+		{
+			switch (RuntimeInformation.ProcessArchitecture)
+			{
+				case Architecture.X64:
+					x64.heif_image_release(image);
+					break;
+				case Architecture.X86:
+					x86.heif_image_release(image);
+					break;
+				default:
+					throw new NotSupportedException($"Current platform ({RuntimeInformation.ProcessArchitecture}) is not supported");
+			}
+		}
 	}
 }

--- a/src/FileOnQ.Imaging.Heif/LibHeif/LibHeif_x64.cs
+++ b/src/FileOnQ.Imaging.Heif/LibHeif/LibHeif_x64.cs
@@ -47,6 +47,9 @@ namespace FileOnQ.Imaging.Heif
 
 			[DllImport(DllName, CharSet = CharSet.Ansi, CallingConvention = CallingConvention.Cdecl)]
 			internal static extern void heif_image_handle_release(ImageHandle* handle);
+
+			[DllImport(DllName, CharSet = CharSet.Ansi, CallingConvention = CallingConvention.Cdecl)]
+			internal static extern void heif_image_release(Image* image);
 		}
 	}
 }

--- a/src/FileOnQ.Imaging.Heif/LibHeif/LibHeif_x86.cs
+++ b/src/FileOnQ.Imaging.Heif/LibHeif/LibHeif_x86.cs
@@ -47,6 +47,9 @@ namespace FileOnQ.Imaging.Heif
 
 			[DllImport(DllName, CharSet = CharSet.Ansi, CallingConvention = CallingConvention.Cdecl)]
 			internal static extern void heif_image_handle_release(ImageHandle* handle);
+
+			[DllImport(DllName, CharSet = CharSet.Ansi, CallingConvention = CallingConvention.Cdecl)]
+			internal static extern void heif_image_release(Image* image);
 		}
 	}
 }

--- a/tests/FileOnQ.Imaging.Heif.Tests/Build/nuget-local.targets
+++ b/tests/FileOnQ.Imaging.Heif.Tests/Build/nuget-local.targets
@@ -3,6 +3,7 @@
 
 	<Target Name="ClearPackageCache" BeforeTargets="DispatchToInnerBuilds" Condition="'$(CI)' == 'false'">
 		<Exec Command="rmdir /s /q %UserProfile%\.nuget\packages\FileOnQ.Imaging.Heif\0.0.0-local.1" />
+		<Exec Command="del FileOnQ.Imaging.Heif.0.0.0-local.1.*" WorkingDirectory="$(ProjectDir)../../" />
 	</Target>
 
 	<Target Name="CreatePackage" AfterTargets="ClearPackageCache" Condition="'$(CI)' == 'false'">


### PR DESCRIPTION
<!-- link your pull request to an open issue -->
Fixes: #21 

## Description
Fixes memory leak when writing `IImage` to storage, the output image was never released. Added new native API invocation to release native image memory.

## Merge Checklist
- [ ] Added unit or integration tests (if not explain)
- [x] Benchmarks are equivalent or faster