### PR TITLE
Adds Readme Instructions for Visual c++ Redistributable

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,12 @@ Install the NuGet package into your target head and any shared projects.
 
 *The NuGet package must be included in the entry point or target head, otherwise the native assemblies won't be copied over to the bin directory correctly.*
 
+### Windows
+Any Windows device running an application using this library requires the Visual C++ Redistributable package installed. See the [Microsoft Visual C++ Redistributable Latest Supported Downloads](https://docs.microsoft.com/en-us/cpp/windows/latest-supported-vc-redist). You will need to install the correct CPU Architecture(s) that your application supports. 
+* [vc_redist.arm64.exe](https://aka.ms/vs/17/release/vc_redist.arm64.exe)
+* [vc_redist.x86.exe](https://aka.ms/vs/17/release/vc_redist.arm64.exe)
+* [vc_redist.x64.exe](https://aka.ms/vs/17/release/vc_redist.arm64.exe)
+
 ## Supported Target Frameworks
 FileOnQ.Imaging.Heif is available for use in the following target frameworks
 


### PR DESCRIPTION
<!-- link your pull request to an open issue -->
Fixes: #40 

## Description
Adds new Windows specific documentation to main repo `README.md`. This new doc communicates to developers that deployment machines will need to have the Visual C++ Redistributable installed otherwise it will not work.

## Merge Checklist
Documentation change, no need for anything on the check-list

- [ ] Added unit or integration tests (if not explain)
- [ ] Benchmarks are equivalent or faster