### PR TITLE
[WIP] Add Benchmark Build Support for Forked Repos

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -235,7 +235,7 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
-            github.issues.createComment({
+            github.rest.issues.createComment({
               issue_number: context.issue.number,
               owner: context.repo.owner,
               repo: context.repo.repo,

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -58,8 +58,7 @@ jobs:
 
       - name: Set Repository and Ref
         run: |
-          echo '${{ fromJSON(steps.find-branch.output.result) }}'
-          $repository = '${{ fromJSON(steps.find-branch.output.result).repo.html_url }}'
+          $repository = '${{ fromJSON(steps.find-branch.output.result).head.repo.html_url }}'
           $ref = '${{ fromJSON(steps.find-branch.output.result).head.ref }}'
           echo "CUSTOM_REPO=$($repository)" >> $env:GITHUB_ENV"
           echo "CUSTOM_REF=$($ref)" >> $env:GITHUB_ENV

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -58,7 +58,7 @@ jobs:
 
       - name: Set Repository and Ref
         run: |
-          echo '${{ steps.find-branch.output.result }}'
+          echo '${{ fromJSON(steps.find-branch.output.result) }}'
           $repository = '${{ fromJSON(steps.find-branch.output.result).repo.html_url }}'
           $ref = '${{ fromJSON(steps.find-branch.output.result).head.ref }}'
           echo "CUSTOM_REPO=$($repository)" >> $env:GITHUB_ENV"

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -58,7 +58,7 @@ jobs:
 
       - name: Set Repository and Ref
         run: |
-          $repository = '${{ fromJSON(steps.find-branch.outputs.result).head.repo.html_url }}'
+          $repository = '${{ fromJSON(steps.find-branch.outputs.result).head.repo.full_name }}'
           $ref = '${{ fromJSON(steps.find-branch.outputs.result).head.ref }}'
           echo "CUSTOM_REPO=$($repository)" >> $env:GITHUB_ENV
           echo "CUSTOM_REF=$($ref)" >> $env:GITHUB_ENV

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -60,7 +60,7 @@ jobs:
         run: |
           $repository = '${{ fromJSON(steps.find-branch.outputs.result).head.repo.html_url }}'
           $ref = '${{ fromJSON(steps.find-branch.outputs.result).head.ref }}'
-          echo "CUSTOM_REPO=$($repository)" >> $env:GITHUB_ENV"
+          echo "CUSTOM_REPO=$($repository)" >> $env:GITHUB_ENV
           echo "CUSTOM_REF=$($ref)" >> $env:GITHUB_ENV
 
       # - name: Set Ref

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,13 +1,26 @@
 name: Benchmark
 
 on:
-  pull_request:
+  pull_request_target:
     branches: [ main ]
 #    types: [ opened ]
   issue_comment:
     types: [ created ]
 
 jobs:
+  test-comment:
+    runs-on: windows-2019
+    steps:
+    uses: actions/github-script@v5
+    with:
+      script: |
+        github.rest.issues.createComment({
+          issue_number: context.issue.number,
+          owner: context.repo.owner,
+          repo: context.repo.repo,
+          body: `Hello World, this is GitHub Actions 👋`
+        })
+
   check-command:
     runs-on: windows-2019
     permissions:
@@ -233,7 +246,6 @@ jobs:
       - name: GitHub Comment - Post
         uses: actions/github-script@v5
         with:
-          github-token: ${{ secrets.MAIN_REPO_GITHUB_TOKEN }}
           script: |
             github.rest.issues.createComment({
               issue_number: context.issue.number,

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -58,7 +58,6 @@ jobs:
 
       - name: Set Repository and Ref
         run: |
-          echo '${{ fromJSON(steps.find-branch.output.result) }}'
           echo '${{ steps.find-branch.output.result }}'
           $repository = '${{ fromJSON(steps.find-branch.output.result).repo.html_url }}'
           $ref = '${{ fromJSON(steps.find-branch.output.result).head.ref }}'

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -11,15 +11,16 @@ jobs:
   test-comment:
     runs-on: windows-2019
     steps:
-    uses: actions/github-script@v5
-    with:
-      script: |
-        github.rest.issues.createComment({
-          issue_number: context.issue.number,
-          owner: context.repo.owner,
-          repo: context.repo.repo,
-          body: `Hello World, this is GitHub Actions 👋`
-        })
+      - name: Comment on PR
+        uses: actions/github-script@v5
+        with:
+        script: |
+          github.rest.issues.createComment({
+            issue_number: context.issue.number,
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            body: `Hello World, this is GitHub Actions 👋`
+          })
 
   check-command:
     runs-on: windows-2019

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -15,6 +15,7 @@ jobs:
     outputs:
       benchmark: ${{ steps.check.outputs.triggered }}
       ref: ${{ env.CUSTOM_REF }}
+      repo: ${{ env.CUSTOM_REPO }}
     steps:
       - name: Print Event Name
         run: echo "${{ github.EVENT_NAME }}"
@@ -29,16 +30,15 @@ jobs:
         env:
           GITHUB_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
 
-      - name: Set Triggered Variable
-        run: |
-          $triggered = 'false'
-          if ('${{ github.EVENT_NAME }}' -ne 'pull_request') {
-            $triggered = '${{ steps.check.outputs.triggered }}'
-          }
-          echo "COMMAND_TRIGGERED=$($triggered)" >> $env:GITHUB_ENV
+      # - name: Set Triggered Variable
+      #   run: |
+      #     $triggered = 'false'
+      #     if ('${{ github.EVENT_NAME }}' -ne 'pull_request') {
+      #       $triggered = '${{ steps.check.outputs.triggered }}'
+      #     }
 
       - name: Find Branch
-        if: ${{ env.COMMAND_TRIGGERED == 'true' }}
+        #if: ${{ env.COMMAND_TRIGGERED == 'true' }}
         uses: actions/github-script@v3
         id: find-branch
         with:
@@ -56,32 +56,41 @@ jobs:
               core.setFailed(`Request failed with error ${err}`)
             }
 
-      - name: Set Branch - Comment
-        if: ${{ env.COMMAND_TRIGGERED == 'true' }}
+      - name: Set Repository & Ref
         run: |
-          $triggered = '${{ env.COMMAND_TRIGGERED }}'
-          $ref = '${{ fromJSON(steps.find-branch.outputs.result).head.ref }}'
+          $repository = '${{ fromJSON(steps.find-branch.output.result).repo.html_url'
+          $ref = '${{ fromJSON(steps.find-branch.output.result).head.ref'
+          echo "CUSTOM_REPO=$($repository)" >> $env:GITHUB_ENV"
           echo "CUSTOM_REF=$($ref)" >> $env:GITHUB_ENV
 
-      - name: Set Branch - Comment
-        if: ${{ env.COMMAND_TRIGGERED == 'false' }}
-        run: |
-          $triggered = '${{ env.COMMAND_TRIGGERED }}'
-          $ref = '${{ github.REF }}'
-          echo "CUSTOM_REF=$($ref)" >> $env:GITHUB_ENV
+      # - name: Set Ref
+      #   #if: ${{ env.COMMAND_TRIGGERED == 'true' }}
+      #   run: |
+      #     $triggered = '${{ env.COMMAND_TRIGGERED }}'
+      #     $ref = '${{ fromJSON(steps.find-branch.outputs.result).head.ref }}'
+      #     echo "CUSTOM_REF=$($ref)" >> $env:GITHUB_ENV
+
+      # - name: Set Branch - Comment
+      #   if: ${{ env.COMMAND_TRIGGERED == 'false' }}
+      #   run: |
+      #     $triggered = '${{ env.COMMAND_TRIGGERED }}'
+      #     $ref = '${{ github.REF }}'
+      #     echo "CUSTOM_REF=$($ref)" >> $env:GITHUB_ENV
 
   benchmark-build:
     if: ${{ needs.check-command.outputs.benchmark == 'true' || github.EVENT_NAME == 'pull_request' }}
     needs: check-command
     runs-on: windows-2019
     outputs:
+      repo: ${{ needs.check-command.outputs.repo }}
       ref: ${{ needs.check-command.outputs.ref }}
       package_version: ${{ env.PACKAGE_VERSION }}
     steps:
       - uses: actions/checkout@v2
         with:
-          submodules: 'true'
+          repository: ${{ needs.check-command.outputs.repo }}
           ref: ${{ needs.check-command.outputs.ref }}
+          submodules: 'true'
 
       - name: Setup .NET SDK
         uses: actions/setup-dotnet@v1
@@ -120,6 +129,7 @@ jobs:
     needs: benchmark-build
     runs-on: ${{ matrix.os }}
     outputs:
+      repo: ${{ needs.benchmark-build.outputs.repo }}
       ref: ${{ needs.benchmark-build.outputs.ref }}
     strategy:
       matrix:
@@ -131,8 +141,9 @@ jobs:
     steps:
       - uses: actions/checkout@v2
         with:
-          submodules: 'true'
+          repository: ${{ needs.benchmark-build.outputs.repo }}
           ref: ${{ needs.benchmark-build.outputs.ref }}
+          submodules: 'true'
 
       - name: Download Artifacts
         uses: actions/download-artifact@v2

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -51,7 +51,7 @@ jobs:
             core.info(`Getting PR #${request.pull_number} from ${request.owner}/${request.repo}`)
             try {
               const result = await github.pulls.get(request)
-              core.info(result.data)
+              core.info(result.data.stringify())
               return result.data
             } catch (err) {
               core.setFailed(`Request failed with error ${err}`)

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -56,7 +56,7 @@ jobs:
               core.setFailed(`Request failed with error ${err}`)
             }
 
-      - name: Set Repository & Ref
+      - name: Set Repository and Ref
         run: |
           $repository = '${{ fromJSON(steps.find-branch.output.result).repo.html_url'
           $ref = '${{ fromJSON(steps.find-branch.output.result).head.ref'

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -231,8 +231,9 @@ jobs:
         working-directory: ./artifacts
 
       - name: GitHub Comment - Post
-        uses: actions/github-script@v4
+        uses: actions/github-script@v5
         with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
             github.issues.createComment({
               issue_number: context.issue.number,

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -58,8 +58,8 @@ jobs:
 
       - name: Set Repository and Ref
         run: |
-          $repository = '${{ fromJSON(steps.find-branch.output.result).repo.html_url'
-          $ref = '${{ fromJSON(steps.find-branch.output.result).head.ref'
+          $repository = '${{ fromJSON(steps.find-branch.output.result).repo.html_url }}'
+          $ref = '${{ fromJSON(steps.find-branch.output.result).head.ref }}'
           echo "CUSTOM_REPO=$($repository)" >> $env:GITHUB_ENV"
           echo "CUSTOM_REF=$($ref)" >> $env:GITHUB_ENV
 

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -2,7 +2,8 @@ name: Benchmark
 
 on:
   pull_request_target:
-    branches: [ main ]
+    types: [ opened, syncrhonize ]
+#    branches: [ main ]
 #    types: [ opened ]
   issue_comment:
     types: [ created ]

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -51,7 +51,6 @@ jobs:
             core.info(`Getting PR #${request.pull_number} from ${request.owner}/${request.repo}`)
             try {
               const result = await github.pulls.get(request)
-              core.info(result.data.stringify())
               return result.data
             } catch (err) {
               core.setFailed(`Request failed with error ${err}`)
@@ -59,6 +58,8 @@ jobs:
 
       - name: Set Repository and Ref
         run: |
+          echo '${{ fromJSON(steps.find-branch.output.result) }}'
+          echo '${{ steps.find-branch.output.result }}'
           $repository = '${{ fromJSON(steps.find-branch.output.result).repo.html_url }}'
           $ref = '${{ fromJSON(steps.find-branch.output.result).head.ref }}'
           echo "CUSTOM_REPO=$($repository)" >> $env:GITHUB_ENV"

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -2,13 +2,13 @@ name: Benchmark
 
 on:
   pull_request_target:
-    types: [ opened, syncrhonize ]
-#    branches: [ main ]
-#    types: [ opened ]
+    branches: [ main ]
+    types: [ opened ]
   issue_comment:
     types: [ created ]
 
 jobs:
+#this is a test job to validate commenting
   test-comment:
     runs-on: windows-2019
     steps:
@@ -45,15 +45,7 @@ jobs:
         env:
           GITHUB_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
 
-      # - name: Set Triggered Variable
-      #   run: |
-      #     $triggered = 'false'
-      #     if ('${{ github.EVENT_NAME }}' -ne 'pull_request') {
-      #       $triggered = '${{ steps.check.outputs.triggered }}'
-      #     }
-
       - name: Find Branch
-        #if: ${{ env.COMMAND_TRIGGERED == 'true' }}
         uses: actions/github-script@v3
         id: find-branch
         with:
@@ -77,19 +69,6 @@ jobs:
           $ref = '${{ fromJSON(steps.find-branch.outputs.result).head.ref }}'
           echo "CUSTOM_REPO=$($repository)" >> $env:GITHUB_ENV
           echo "CUSTOM_REF=$($ref)" >> $env:GITHUB_ENV
-
-      # - name: Set Ref
-      #   run: |
-      #     $triggered = '${{ env.COMMAND_TRIGGERED }}'
-      #     $ref = '${{ fromJSON(steps.find-branch.outputs.result).head.ref }}'
-      #     echo "CUSTOM_REF=$($ref)" >> $env:GITHUB_ENV
-
-      # - name: Set Branch - Comment
-      #   if: ${{ env.COMMAND_TRIGGERED == 'false' }}
-      #   run: |
-      #     $triggered = '${{ env.COMMAND_TRIGGERED }}'
-      #     $ref = '${{ github.REF }}'
-      #     echo "CUSTOM_REF=$($ref)" >> $env:GITHUB_ENV
 
   benchmark-build:
     if: ${{ needs.check-command.outputs.benchmark == 'true' || github.EVENT_NAME == 'pull_request' }}

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -173,6 +173,7 @@ jobs:
       - name: Clone fileonq/imaging.heif
         uses: actions/checkout@v2
         with:
+          repository: ${{ needs.benchmark-run.outputs.repo }}
           ref: ${{ needs.benchmark-run.outputs.ref }}
           path: fileonq.imaging.heif
 

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -58,13 +58,12 @@ jobs:
 
       - name: Set Repository and Ref
         run: |
-          $repository = '${{ fromJSON(steps.find-branch.output.result).head.repo.html_url }}'
-          $ref = '${{ fromJSON(steps.find-branch.output.result).head.ref }}'
+          $repository = '${{ fromJSON(steps.find-branch.outputs.result).head.repo.html_url }}'
+          $ref = '${{ fromJSON(steps.find-branch.outputs.result).head.ref }}'
           echo "CUSTOM_REPO=$($repository)" >> $env:GITHUB_ENV"
           echo "CUSTOM_REF=$($ref)" >> $env:GITHUB_ENV
 
       # - name: Set Ref
-      #   #if: ${{ env.COMMAND_TRIGGERED == 'true' }}
       #   run: |
       #     $triggered = '${{ env.COMMAND_TRIGGERED }}'
       #     $ref = '${{ fromJSON(steps.find-branch.outputs.result).head.ref }}'

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -3,7 +3,7 @@ name: Benchmark
 on:
   pull_request:
     branches: [ main ]
-    types: [ opened ]
+#    types: [ opened ]
   issue_comment:
     types: [ created ]
 
@@ -51,6 +51,7 @@ jobs:
             core.info(`Getting PR #${request.pull_number} from ${request.owner}/${request.repo}`)
             try {
               const result = await github.pulls.get(request)
+              core.info(result.data)
               return result.data
             } catch (err) {
               core.setFailed(`Request failed with error ${err}`)

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -233,7 +233,7 @@ jobs:
       - name: GitHub Comment - Post
         uses: actions/github-script@v5
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          github-token: ${{ secrets.MAIN_REPO_GITHUB_TOKEN }}
           script: |
             github.rest.issues.createComment({
               issue_number: context.issue.number,


### PR DESCRIPTION
Gets us started with supporting Forked repos. To properly test this will need to be merged to main

Fixes: #45 

## Description
Changes how we retrieve the repo owner and ref so benchmarks can be ran if a PR is submitted from a forked repo

## Merge Checklist
- [ ] Added unit or integration tests (if not explain)
- [x] Benchmarks are equivalent or faster