### PR TITLE
Added deterministic build for nuget.props instead of build

### DIFF
--- a/.github/workflows/build_main.yml
+++ b/.github/workflows/build_main.yml
@@ -49,7 +49,7 @@ jobs:
       working-directory: ./src/FileOnQ.Imaging.Heif
       
     - name: Pack
-      run: dotnet pack -c Release -o ../../ /p:ContinuousIntegrationBuild=true /p:Version=${{ env.PACKAGE_VERSION }} /p:PackageVersion=${{ env.PACKAGE_VERSION }}
+      run: dotnet pack -c Release -o ../../ /p:Version=${{ env.PACKAGE_VERSION }} /p:PackageVersion=${{ env.PACKAGE_VERSION }}
       working-directory: ./src/FileOnQ.Imaging.Heif
       
     - name: Upload NuGet Package

--- a/.github/workflows/build_pr.yml
+++ b/.github/workflows/build_pr.yml
@@ -36,10 +36,12 @@ jobs:
       run: echo "PACKAGE_VERSION=1.0.0-pr.${{ GITHUB.RUN_NUMBER }}" >> $env:GITHUB_ENV
 
     - name: Build
-      run: dotnet build src/FileOnQ.Imaging.Heif/FileOnQ.Imaging.Heif.csproj -c Release
+      run: dotnet build -c Release
+      working-directory: ./src/FileOnQ.Imaging.Heif
       
     - name: Pack
-      run: dotnet pack src/FileOnQ.Imaging.Heif/FileOnQ.Imaging.Heif.csproj -c Release -o . /p:ContinuousIntegrationBuild=true /p:Version=${{ env.PACKAGE_VERSION }} /p:PackageVersion=${{ env.PACKAGE_VERSION }}
+      run: dotnet pack -c Release -o ../../ /p:Version=${{ env.PACKAGE_VERSION }} /p:PackageVersion=${{ env.PACKAGE_VERSION }}
+      working-directory: ./src/FileOnQ.Imaging.Heif
       
     - name: Upload NuGet Package
       uses: actions/upload-artifact@v2

--- a/src/FileOnQ.Imaging.Heif/Build/nuget.props
+++ b/src/FileOnQ.Imaging.Heif/Build/nuget.props
@@ -27,6 +27,10 @@
 		<!-- End NuGet Symbols Package Properties -->
 	</PropertyGroup>
 
+	<PropertyGroup Condition="'$(GITHUB_ACTIONS)' == 'true'">
+		<ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>
+	</PropertyGroup> 
+
 	<ItemGroup>
 		<PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
 	</ItemGroup>


### PR DESCRIPTION
Fixes: #80

## Description
Removes /p:ContinuousBuildIntegration=true from build commands and included as part of the nuget.props file. This will ensure whenever it is being built on GitHub Actions our dlls are deterministic.

## Merge Checklist
- [ ] Added unit or integration tests (if not explain)
- [ ] Benchmarks are equivalent or faster