### PR TITLE
Added libde265 as third-party Compilation Instead of Using vcpkg

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -31,7 +31,7 @@ C:\Program Files\Meson
 *In our environment `nasm` was not automatically added to the path, but the other dependencies were*
 
 ## Compile
-First time compilation takes a very long time, after you start the build go grab a cup of ☕ or 🍵. Our build agent runs the entire clean build in about 25-35 minutes, your build times may vary. Future builds won't take as long even if you do a clean and rebuild as vcpkg will cache binaries in your user directory. 
+First time compilation takes a very long time, after you start the build go grab a cup of ☕ or 🍵. Our build agent runs the entire clean build in about 25-35 minutes, your build times may vary.
 
 By compiling the main project `FileOnQ.Imaging.Heif` you will be compiling all native dependencies including the C++ encoding library `FileOnQ.Imaging.Heif.Encoders`. No need to run any additional compilation instructions.
 

--- a/build/libde265.bat
+++ b/build/libde265.bat
@@ -1,0 +1,10 @@
+@echo off
+title Building libde265
+set arch=%1
+set config=%2
+call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvarsall.bat" %arch%
+cd ../third-party/libde265-%arch%
+mkdir build
+cd build
+cmake -G"NMake Makefiles" -DCMAKE_BUILD_TYPE=%config% ..
+nmake

--- a/build/libde265.bat
+++ b/build/libde265.bat
@@ -4,7 +4,5 @@ set arch=%1
 set config=%2
 call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvarsall.bat" %arch%
 cd ../third-party/libde265-%arch%
-mkdir build
-cd build
-cmake -G"NMake Makefiles" -DCMAKE_BUILD_TYPE=%config% ..
+cmake -G"NMake Makefiles" -DCMAKE_BUILD_TYPE=%config% .
 nmake

--- a/build/libheif.bat
+++ b/build/libheif.bat
@@ -16,8 +16,8 @@ cmake -G"NMake Makefiles"^
  -DJPEG_INCLUDE_DIR:PATH=%thirdPartyPath%\libjpeg-turbo-%arch%^
  -DJPEG_LIBRARY_DEBUG:FILEPATH=%thirdPartyPath%\libjpeg-turbo-%arch%\jpeg.lib^
  -DJPEG_LIBRARY_RELEASE:FILEPATH=%thirdPartyPath%\libjpeg-turbo-%arch%\jpeg.lib^
- -DLIBDE265_INCLUDE_DIR:PATH=%thirdPartyPath%\vcpkg\installed\%arch%-windows\include^
- -DLIBDE265_LIBRARY:FILEPATH=%thirdPartyPath%\vcpkg\installed\%arch%-windows\lib\libde265.lib^
+ -DLIBDE265_INCLUDE_DIR:PATH=%thirdPartyPath%\libde265-%arch%\build^
+ -DLIBDE265_LIBRARY:FILEPATH=%thirdPartyPath%\libde265-%arch%\build\libde265\libde265.lib^
  ..
 
 nmake

--- a/build/libheif.bat
+++ b/build/libheif.bat
@@ -16,8 +16,8 @@ cmake -G"NMake Makefiles"^
  -DJPEG_INCLUDE_DIR:PATH=%thirdPartyPath%\libjpeg-turbo-%arch%^
  -DJPEG_LIBRARY_DEBUG:FILEPATH=%thirdPartyPath%\libjpeg-turbo-%arch%\jpeg.lib^
  -DJPEG_LIBRARY_RELEASE:FILEPATH=%thirdPartyPath%\libjpeg-turbo-%arch%\jpeg.lib^
- -DLIBDE265_INCLUDE_DIR:PATH=%thirdPartyPath%\libde265-%arch%\build^
- -DLIBDE265_LIBRARY:FILEPATH=%thirdPartyPath%\libde265-%arch%\build\libde265\libde265.lib^
+ -DLIBDE265_INCLUDE_DIR:PATH=%thirdPartyPath%\libde265-%arch%^
+ -DLIBDE265_LIBRARY:FILEPATH=%thirdPartyPath%\libde265-%arch%\libde265\libde265.lib^
  ..
 
 nmake

--- a/src/FileOnQ.Imaging.Heif/Build/libde265.targets
+++ b/src/FileOnQ.Imaging.Heif/Build/libde265.targets
@@ -15,8 +15,8 @@
 		<Exec Command="libde265.bat x86 $(Configuration)" WorkingDirectory="$(ThirdPartyDir)/../build" />
 		<Exec Command="libde265.bat x64 $(Configuration)" WorkingDirectory="$(ThirdPartyDir)/../build" />
 
-		<Copy SourceFiles="$(ThirdPartyDir)/libde265-x86/build/libde265/libde265.dll" DestinationFolder="runtimes/win-x86/native" />
-		<Copy SourceFiles="$(ThirdPartyDir)/libde265-x64/build/libde265/libde265.dll" DestinationFolder="runtimes/win-x64/native" />
+		<Copy SourceFiles="$(ThirdPartyDir)/libde265-x86/libde265/libde265.dll" DestinationFolder="runtimes/win-x86/native" />
+		<Copy SourceFiles="$(ThirdPartyDir)/libde265-x64/libde265/libde265.dll" DestinationFolder="runtimes/win-x64/native" />
 	</Target>
 
 	<Target Name="libde265-clean" BeforeTargets="Clean">

--- a/src/FileOnQ.Imaging.Heif/Build/libde265.targets
+++ b/src/FileOnQ.Imaging.Heif/Build/libde265.targets
@@ -1,0 +1,28 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<Project ToolsVersion="15.0">
+
+	<Target Name="libde265-clone-x86" Condition="!Exists('$(ThirdPartyDir)/libde265-x86/README.md')">
+		<Exec Command="git clone https://github.com/strukturag/libde265.git libde265-x86" WorkingDirectory="$(ThirdPartyDir)" />
+		<Exec Command="git checkout v1.0.8" WorkingDirectory="$(ThirdPartyDir)/libde265-x86" />
+	</Target>
+
+	<Target Name="libde265-clone-x64" Condition="!Exists('$(ThirdPartyDir)/libde265-x64/README.md')">
+		<Exec Command="git clone https://github.com/strukturag/libde265.git libde265-x64" WorkingDirectory="$(ThirdPartyDir)" />
+		<Exec Command="git checkout v1.0.8" WorkingDirectory="$(ThirdPartyDir)/libde265-x64" />
+	</Target>
+
+	<Target Name="libde265" DependsOnTargets="libde265-clone-x64;libde265-clone-x86" Condition="!Exists('runtimes/win-x64/native/libde265.dll') and !Exists('runtimes/win-x86/native/libde265.dll')">
+		<Exec Command="libde265.bat x86 $(Configuration)" WorkingDirectory="$(ThirdPartyDir)/../build" />
+		<Exec Command="libde265.bat x64 $(Configuration)" WorkingDirectory="$(ThirdPartyDir)/../build" />
+
+		<Copy SourceFiles="$(ThirdPartyDir)/libde265-x86/build/libde265/libde265.dll" DestinationFolder="runtimes/win-x86/native" />
+		<Copy SourceFiles="$(ThirdPartyDir)/libde265-x64/build/libde265/libde265.dll" DestinationFolder="runtimes/win-x64/native" />
+	</Target>
+
+	<Target Name="libde265-clean" BeforeTargets="Clean">
+		<Exec Command="rmdir /s /q libde265-x86" WorkingDirectory="$(ThirdPartyDir)" Condition="Exists('$(ThirdPartyDir)/libde265-x86/README.md')" />
+		<Exec Command="rmdir /s /q libde265-x64" WorkingDirectory="$(ThirdPartyDir)" Condition="Exists('$(ThirdPartyDir)/libde265-x64/README.md')" />
+		<Delete Files="runtimes/win-x86/native/libde265.dll" />
+		<Delete Files="runtimes/win-x64/native/libde265.dll" />
+	</Target>
+</Project>

--- a/src/FileOnQ.Imaging.Heif/Build/libheif.targets
+++ b/src/FileOnQ.Imaging.Heif/Build/libheif.targets
@@ -23,11 +23,7 @@
 		<Copy SourceFiles="@(IncludeFiles_x64)" DestinationFiles="@(IncludeFiles_x64->'$(ThirdPartyDir)/libheif-x64/libheif/%(RecursiveDir)%(Filename)%(Extension)')" />
 	</Target>
 
-	<Target Name="LibHeif-Dependencies" DependsOnTargets="Vcpkg;libjpeg-turbo;dav1d" Condition="!Exists('dav1d.dll') and !Exists('libde265.dll')">
-		<Exec Command="vcpkg.exe install libde265:x64-windows" WorkingDirectory="$(ThirdPartyDir)/vcpkg" />
-		<Copy SourceFiles="$(ThirdPartyDir)/vcpkg/installed/x64-windows/bin/libde265.dll" DestinationFolder="runtimes/win-x64/native" />
-		<Exec Command="vcpkg.exe install libde265:x86-windows" WorkingDirectory="$(ThirdPartyDir)/vcpkg" />
-		<Copy SourceFiles="$(ThirdPartyDir)/vcpkg/installed/x86-windows/bin/libde265.dll" DestinationFolder="runtimes/win-x86/native" />
+	<Target Name="LibHeif-Dependencies" DependsOnTargets="libde265;libjpeg-turbo;dav1d" Condition="!Exists('dav1d.dll') and !Exists('libde265.dll')">
 	</Target>
 
 	<Target Name="LibHeif-Clone-x86" Condition="!Exists('$(ThirdPartyDir)/libheif-x86/README.md')">
@@ -40,18 +36,9 @@
 		<Exec Command="git checkout v1.12.0" WorkingDirectory="$(ThirdPartyDir)/libheif-x64" />
 	</Target>
 
-	<Target Name="Vcpkg" Condition="!Exists('$(ThirdPartyDir)/vcpkg/vcpkg.exe')">
-		<Exec Command="git clone https://github.com/microsoft/vcpkg" WorkingDirectory="$(ThirdPartyDir)" />
-		<Exec Command="bootstrap-vcpkg.bat" WorkingDirectory="$(ThirdPartyDir)/vcpkg" />
-	</Target>
-
 	<Target Name="LibHeif-Clean" BeforeTargets="Clean" >
 		<Exec Command="rmdir /s /q libheif-x86" WorkingDirectory="$(ThirdPartyDir)" Condition="Exists('$(ThirdPartyDir)/libheif-x86/README.md')" />
 		<Exec Command="rmdir /s /q libheif-x64" WorkingDirectory="$(ThirdPartyDir)" Condition="Exists('$(ThirdPartyDir)/libheif-x64/README.md')" />
-	</Target>
-
-	<Target Name="vcpkg-clean" BeforeTargets="Clean" Condition="Exists('$(ThirdPartyDir)/vcpkg/vcpkg.exe')">
-		<Exec Command="rmdir /s /q vcpkg" WorkingDirectory="$(ThirdPartyDir)" />
 	</Target>
 
 	<Target Name="CleanLibHeif" BeforeTargets="Clean">

--- a/src/FileOnQ.Imaging.Heif/FileOnQ.Imaging.Heif.csproj
+++ b/src/FileOnQ.Imaging.Heif/FileOnQ.Imaging.Heif.csproj
@@ -13,7 +13,8 @@
 	<Import Project="Build\build-properties.props" />
 	<Import Project="Build\dav1d.targets" />
 	<Import Project="Build\encoders.targets" />
-	<Import Project="Build\libheif.targets" />
+	<Import Project="Build\libde265.targets" />
 	<Import Project="Build\libjpeg-turbo.targets" />
+	<Import Project="Build\libheif.targets" />
 
 </Project>


### PR DESCRIPTION
<!-- link your pull request to an open issue -->
Fixes: #88 

## Description
Removes vcpkg and updates the build to clone and compile libde265. This is important step to fully supporting cross-platform compilation as vcpkg is focused on windows.

## Merge Checklist
- [ ] Added unit or integration tests (if not explain)
- [x] Benchmarks are equivalent or faster