### PR TITLE
Prevent publishing dev builds to NuGet

### DIFF
--- a/.github/workflows/build_main.yml
+++ b/.github/workflows/build_main.yml
@@ -1,9 +1,9 @@
-name: Build (1.0.1)
+name: Build
 
 on:
    push:
      branches: [ main ]
-     tags: [ 'v*', 'v*-preview-*']
+     tags: [ 'v*' ]
 
 env:
   version: "1.0.1"
@@ -245,6 +245,7 @@ jobs:
         working-directory: ./samples/WinformsApp/WinformsApp.${{ matrix.framework }}
         
   nuget-publish:
+    if: startsWith(github.ref, 'refs/tags/v') == true
     needs: [test-integration, test-console-app, build-win-forms-app]
     runs-on: windows-2019
     steps:
@@ -260,7 +261,7 @@ jobs:
         run: nuget push *.nupkg -Source https://api.nuget.org/v3/index.json
 
   create-release:
-    if: startsWith(github.ref, 'refs/tags/v') == true && contains(github.ref, 'preview') == false
+    if: startsWith(github.ref, 'refs/tags/v') == true
     needs: [test-integration, test-console-app, build-win-forms-app]
     runs-on: windows-latest
     steps:

--- a/.github/workflows/build_pr.yml
+++ b/.github/workflows/build_pr.yml
@@ -1,4 +1,4 @@
-name: Build PR (1.0.1)
+name: Build PR
 
 on:
    pull_request:


### PR DESCRIPTION
Fixes: #93 

## Description
Prevents dev builds from being published to the public NuGet

## Merge Checklist
- [ ] Added unit or integration tests (if not explain)
- [x] Benchmarks are equivalent or faster